### PR TITLE
Update to check if isRelativePath is null/empty/undefined and default to true

### DIFF
--- a/addon/services/asset-map.js
+++ b/addon/services/asset-map.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import Service from '@ember/service';
 import { debug, warn } from '@ember/debug';
 import { isNone } from '@ember/utils';
@@ -17,7 +18,7 @@ export default Service.extend({
     const ENV = owner.factoryFor('config:environment').class;
     const config = ENV.theme;
 
-    if (!config.isRelativePath) {
+    if (Ember.isPresent(config.isRelativePath) && !config.isRelativePath) {
       this.set('isRelativePath', false);
     }
   },


### PR DESCRIPTION
This PR will check  if the "isRelativePath" configuration is provided at all. In case this property is not provided in the "config", this newly added condition will default its value to "true"(which is the expected behaviour) whereas it was defaulting it to "false" earlier whenever this property was not provided.

So, in the config/environment.js
 theme: {
      isRelativePath: true //will set it to true
 }

theme: {
      isRelativePath: false //will set it to false
 }

theme: {
      //nothing configured for "isRelativePath" will default it to true
 }