### PR TITLE
Initializer of asset-map updated to have null-check for theme config

### DIFF
--- a/app/initializers/asset-map.js
+++ b/app/initializers/asset-map.js
@@ -15,7 +15,7 @@ export function initialize(app) {
 
   app.deferReadiness();
 
-  const useAssetMap = isNone(Configuration.theme) && isNone(Configuration.theme.useAssetMap) ?
+  const useAssetMap = (isNone(Configuration.theme) && isNone(Configuration.theme.useAssetMap)) ?
     Configuration.environment === 'production' :
     Configuration.theme.useAssetMap;
 

--- a/app/initializers/asset-map.js
+++ b/app/initializers/asset-map.js
@@ -15,7 +15,7 @@ export function initialize(app) {
 
   app.deferReadiness();
 
-  const useAssetMap = isNone(Configuration.theme.useAssetMap) ?
+  const useAssetMap = isNone(Configuration.theme) && isNone(Configuration.theme.useAssetMap) ?
     Configuration.environment === 'production' :
     Configuration.theme.useAssetMap;
 


### PR DESCRIPTION
 The initializer of the asset-map is checking if the theme.defaultTheme is null or not which is already present in there.

 A new condition added to the initializer where it now checks if the "theme" object is null or not in addition to the above null-check.

This is being added to handle the error which is occurring in prod environment.
TypeError: Cannot read property 'useAssetMap' of undefined
